### PR TITLE
Swap backspace/delete variant keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Additionally, while using the switcher for symbol specification, the `A` and `O`
 
  | symbol pattern                                 | output | name |
  |------------------------------------------------|--------|------|
- | ![tab Pattern Diagram](img/s-tab.png)          | `tab`, `delete`, `backspace`, `escape` | `tab`, `delete`, `backspace`, `escape` |
+ | ![tab Pattern Diagram](img/s-tab.png)          | `tab`, `backspace`, `delete`, `escape` | `tab`, `backspace`, `delete`, `escape` |
  | ![arrow Pattern Diagram](img/s-arrow.png) | `up`, `left`, `right`, `down` | `up`, `left`, `right`, `down` |
  | ![page Pattern Diagram](img/s-page.png) | `pageup`, `home`, `end`, `pagedown` | `pageup`, `home`, `end`, `pagedown` |
  | ![blank Pattern Diagram](img/s-blank.png) | `escape`, `tab`, `return`, ` ` | `escape`, `tab`, `return`, `space` |

--- a/emily-modifiers.py
+++ b/emily-modifiers.py
@@ -42,7 +42,7 @@ spelling = {
 
 # same as emily-symbols format, but modified for use on the left hand
 symbols = {
-        "TR"    : ["tab", "delete", "backspace", "escape"],
+        "TR"    : ["tab", "backspace", "delete", "escape"],
         "KPWR"  : ["up", "left", "right", "down"],
         "KPWHR" : ["page_up", "home", "end", "page_down"],
         ""      : ["", "tab", "return", "space"],


### PR DESCRIPTION
Hello,

I've noticed that the 'delete' and 'backspace' strokes seem to be reversed from what is indicated on emily-modifiers-poster.pdf.

| Stroke | Translation on `master` version | Expected translation |
| -- | -- | -- |
| `TRA*LTZ` |  {#delete} | {#backspace} |
| `TRO*LTZ` | {#backspace} | {#delete} |

The 'A' key generally maps to leftward-moving commands (left, home) and the 'O' key their rightward-moving counterparts. Since backspace erases to the left, it makes sense to associate it with 'A'.

This PR swaps the two translations, so that the output matches the 'expected translation' column above (as well as the poster PDF).

Thanks!